### PR TITLE
PE package suffix as config variable 

### DIFF
--- a/lib/pe_build/config.rb
+++ b/lib/pe_build/config.rb
@@ -6,6 +6,7 @@ class PEBuild::Config < Vagrant::Config::Base
   attr_writer :download_root
   attr_writer :version
   attr_writer :filename
+  attr_writer :suffix
 
   def download_root
     @download_root
@@ -17,6 +18,10 @@ class PEBuild::Config < Vagrant::Config::Base
 
   def filename
     @filename
+  end
+
+  def suffix
+    @suffix || :all
   end
 
   def validate(env, errors)

--- a/lib/pe_build/provisioners/puppet_enterprise_bootstrap.rb
+++ b/lib/pe_build/provisioners/puppet_enterprise_bootstrap.rb
@@ -73,11 +73,13 @@ class PEBuild::Provisioners::PuppetEnterpriseBootstrap < Vagrant::Provisioners::
       @root     = @env[:vm].pe_build.download_root
       @version  = @env[:vm].pe_build.version
       @filename = @env[:vm].pe_build.version
+      @suffix   = @env[:vm].pe_build.suffix
     end
 
     @root     ||= @env[:global_config].pe_build.download_root
     @version  ||= @env[:global_config].pe_build.version
     @filename ||= @env[:global_config].pe_build.filename
+    @suffix   ||= @env[:global_config].pe_build.suffix
   end
 
   def prepare_answers_file
@@ -116,7 +118,7 @@ class PEBuild::Provisioners::PuppetEnterpriseBootstrap < Vagrant::Provisioners::
   # @todo Don't restrict this to the universal installer
   def configure_installer
     vm_base_dir = "/vagrant/.pe_build"
-    installer   = "#{vm_base_dir}/puppet-enterprise-#{@version}-all/puppet-enterprise-installer"
+    installer   = "#{vm_base_dir}/puppet-enterprise-#{@version}-#{@suffix}/puppet-enterprise-installer"
     answers     = "#{vm_base_dir}/answers/#{@env[:vm].name}.txt"
     log_file    = "/root/puppet-enterprise-installer-#{Time.now.strftime('%s')}.log"
 


### PR DESCRIPTION
This provisioner already has a way to specify the version of PE desire.
By allowing users to select a suffix for a particular machine, we do
not need to download the 'all' version of PE. This could potentially
save some time, as the platform specific version are smaller.
