### PR TITLE
Rename master answer template, add enhancements.

### DIFF
--- a/templates/answers/master.txt.erb
+++ b/templates/answers/master.txt.erb
@@ -1,14 +1,14 @@
 q_install=y
-q_puppet_cloud_install=n
+q_puppet_cloud_install=y
 
 q_puppet_enterpriseconsole_auth_database_name=console_auth
 q_puppet_enterpriseconsole_auth_database_password=console_auth
 q_puppet_enterpriseconsole_auth_database_user=console_auth
-q_puppet_enterpriseconsole_auth_password=console
-q_puppet_enterpriseconsole_auth_user_email=console@example.com
+q_puppet_enterpriseconsole_auth_password=vagrant
+q_puppet_enterpriseconsole_auth_user_email=vagrant@example.com
 
-# Use existing database
-q_puppet_enterpriseconsole_database_install=n
+# Create New Database
+q_puppet_enterpriseconsole_database_install=y
 q_puppet_enterpriseconsole_setup_db=y
 
 q_puppet_enterpriseconsole_database_name=console


### PR DESCRIPTION
In commit d9be734, the name of the built-in template was changed and no
longer conformed with how the provisioner found default answer files.
Default answer files are used in the absence of a user provided answer.
They contain safe defaults to bring up a generally default master or
agent.

This commit restores the master.txt.erb file as well as chaging a few
values to safer defaults. The previous file assumed a pre-installed
MySQL server, the new settings assume the PE installer will be
installing the MySQL server. The default username and password were
changed to vagrant@example.com and vagrant respectively. These new
default console credentials reflect the defaults that Vagrant boxes are
supposed to contain.
