### PR TITLE
Correct provisioner variable in 'unpackage' action

### DIFF
--- a/lib/pe_build/action/unpackage.rb
+++ b/lib/pe_build/action/unpackage.rb
@@ -26,7 +26,7 @@ class Unpackage
     if @env[:box_name]
       @root     = @env[:vm].pe_build.download_root
       @version  = @env[:vm].pe_build.version
-      @filename = @env[:vm].pe_build.version
+      @filename = @env[:vm].pe_build.filename
     end
 
     @root     ||= @env[:global_config].pe_build.download_root


### PR DESCRIPTION
The PEBuild::Action::Unpackage class checks both :global_config variables
and :vm specific variables to determine its operation. Without this
commit, the :vm variable referred to for 'filename' is incorrect and
referes to the :vm 'version' variable instead.

This commit corrects the reference to the :vm 'filename' configuration
variable.
