### PR TITLE
Use @env hash in `PEBuild::Action::Download`

### DIFF
--- a/lib/pe_build/action/download.rb
+++ b/lib/pe_build/action/download.rb
@@ -44,7 +44,7 @@ class Download
   end
 
   def perform_download
-    archive = PEBuild::Archive.new(@filename, @env[:ui])
+    archive = PEBuild::Archive.new(@filename, @env)
     archive.version = @version
     archive.download_from(@root)
   end

--- a/lib/pe_build/archive.rb
+++ b/lib/pe_build/archive.rb
@@ -25,7 +25,7 @@ class Archive
   attr_accessor :env
 
   # @param filename [String] The uninterpolated filename
-  # @param env [Vagrant::Environment]
+  # @param env [Hash]
   def initialize(filename, env)
     @filename = filename
     @env      = env

--- a/lib/pe_build/idempotent.rb
+++ b/lib/pe_build/idempotent.rb
@@ -7,7 +7,7 @@ module Idempotent
     desc ||= fpath
 
     if File.exist? fpath
-      @env.ui.info "#{desc} is already present."
+      @env[:ui].info "#{desc} is already present."
     else
       yield
     end


### PR DESCRIPTION
Without this commit, the attempt to output using the Vagrant "ui" facility
fails in `PEBuild::Idempotent#idempotent`.

The class `PEBuild::Action::Download` receives a hash that represents a
merge between the current provisioner being invoked and the global
configuration applied to the VM. The value accessed by the `:ui` key in the
hash is then passed to an instance of the `PEBuild::Archive`. The
`PEBuild::Archive` class includes the `PEBuild::Idempotent` module. The
method `PEBuild::Idempotent#idempotent` is incorrectly treating the
`Vagrant::UI::Interface` object as an instance of `Vagrant::Environment`,
causing an error.

This commit corrects this issue by passing the environment hash all the way
through to the `PEBuild::Archive` class. The method in
`PEBuild::Idempotent` has also been changed to access the `:ui` key from
the hash.
