### PR TITLE
Change default filename param to include :version

### DIFF
--- a/lib/pe_build/config/global.rb
+++ b/lib/pe_build/config/global.rb
@@ -35,7 +35,7 @@ class Global < Vagrant.plugin('2', :config)
   def finalize!
     set_default :@suffix,   'all'
     #set_default :@version,  DEFAULT_PE_VERSION
-    set_default :@filename, "puppet-enterprise-#{version}-#{suffix}.tar.gz"
+    set_default :@filename, "puppet-enterprise-:version-#{suffix}.tar.gz"
 
     set_default :@download_root, nil
   end


### PR DESCRIPTION
Without this commit, the default value used by the global configuration
does not properly handle version if it is not defined globally. There is
already functionality in `PEBuild::Archive` that will replace the
string ":version" with the version number passed from the merged
configurations.

This commit updates the default value for the global configuration
parameter "filename" to use the string ":version".
