### PR TITLE
Revert "Only try to download installer if it's present"

### DIFF
--- a/lib/pe_build/provisioner/pe_bootstrap.rb
+++ b/lib/pe_build/provisioner/pe_bootstrap.rb
@@ -56,7 +56,7 @@ class PEBootstrap < Vagrant.plugin('2', :provisioner)
     archive = PEBuild::Archive.new(@config.filename, @machine.env)
     archive.version = @config.version
 
-    archive.download_from(@config.download_root) if @config.download_root
+    archive.download_from(@config.download_root)
     archive.unpack_to(@work_dir)
   end
 


### PR DESCRIPTION
This commit was bypassing the downloads ability to detect the issue give the user more info.
