### PR TITLE
Lazy binding of variables for global 'filename' default

### DIFF
--- a/lib/pe_build/config/global.rb
+++ b/lib/pe_build/config/global.rb
@@ -22,11 +22,14 @@ class Global < Vagrant.plugin('2', :config)
   attr_accessor :suffix
 
   # Allow our filename default to use @version and @suffix variables. This
-  # approach will not break the merging meachnism since the merging directly
+  # approach will not break the merging mechanism since the merging directly
   # accesses the instance variables of the configuration objects.
   def filename
-    return "puppet-enterprise-#{version}-#{suffix}.tar.gz" if @filename == UNSET_VALUE
-    @filename
+    if @filename == UNSET_VALUE
+      "puppet-enterprise-#{version}-#{suffix}.tar.gz"
+    else
+      @filename
+    end
   end
 
   # @!attribute filename
@@ -44,7 +47,6 @@ class Global < Vagrant.plugin('2', :config)
   def finalize!
     set_default :@suffix,   'all'
     #set_default :@version,  DEFAULT_PE_VERSION
-    #set_default :@filename, "puppet-enterprise-:version-#{suffix}.tar.gz"
 
     set_default :@download_root, nil
   end


### PR DESCRIPTION
Without this commit, the default value of the config 'filename'
attirbute was dependant on the values of the @version and @suffix
variables pre-merge time. Since these variables need only be set at
either global or local levels, there is no way to resolve their usage in
this default until the merge.

This code changes the default value to use the @version and @suffix
variables of the local object (which will be post merge in this case) in
the event the @filename variable is set to
`Vagrant::Plugin::V2::Config::UNSET_VALUE`.
