### PR TITLE
Trap SSLError and SocketError during download

### DIFF
--- a/lib/pe_build/transfer/open_uri.rb
+++ b/lib/pe_build/transfer/open_uri.rb
@@ -25,7 +25,7 @@ class PEBuild::Transfer::OpenURI
       tmpfile = download_file
       FileUtils.mv(tmpfile, @dst)
     end
-  rescue ::OpenURI::HTTPError => e
+  rescue ::OpenURI::HTTPError, ::OpenSSL::SSL::SSLError, ::SocketError => e
     raise DownloadFailed, :uri => @uri, :msg => e.message
   end
 


### PR DESCRIPTION
During `vagrant up` (specifically, during the `import` action), if an
exception is raised that does not inherit from `VagrantError` then
Vagrant will forcibly destroy the box.

This patch rescues two additional exception classes raised during download of
PE installers:
- `SocketError` which can be raised if an incorrect URL is provided.
- `SSLError` which can be raised if a `https` URL cannot be validated.

The errors are re-raised as `DownloadFailed` which is a subclass of
`VagrantError`.
