### PR TITLE
More error handling

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -9,6 +9,10 @@ en:
         https://puppetlabs.com/puppet/puppet-enterprise/
       archive: |-
         Tried to unpack %{filename} but it was not downloaded!
+      unreadable: |-
+        Failed to unpack %{filename}.
+        Archive corrupted or otherwise unreadable. The error message generated was:
+        "%{message}"
     provisioner:
       pe_bootstrap:
         post_install: |-


### PR DESCRIPTION
Upgrade missing archive to a proper `VagrantError` and add error handling for archives that cannot be opened because they are corrupted or not in the format their filename claims.
