### PR TITLE
Fix message definition for ArchiveMissing

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -7,7 +7,7 @@ en:
         mirror, or add the installer yourself by using the `vagrant pe-build copy`
         command. Downloads for Puppet Enterprise are available for download at
         https://puppetlabs.com/puppet/puppet-enterprise/
-      archive: |-
+      missing: |-
         Tried to unpack %{filename} but it was not downloaded!
       unreadable: |-
         Failed to unpack %{filename}.


### PR DESCRIPTION
The message should be defined under the key `:missing`, not `:archive`.

Fixup for 6252410.
