### PR TITLE
fix vargrant pe-build copy exception cause by string concatenation

### DIFF
--- a/lib/pe_build/archive.rb
+++ b/lib/pe_build/archive.rb
@@ -59,7 +59,7 @@ module PEBuild
         raise PEBuild::ArchiveNoInstallerSource, :filename => versioned_path(@filename)
       end
 
-      uri = URI.parse(versioned_path(str + '/' + @filename))
+      uri = URI.parse(versioned_path("#{str}/#{@filename}"))
       dst = File.join(@archive_dir, versioned_path(@filename))
 
       transfer = PEBuild::Transfer.generate(uri, dst)


### PR DESCRIPTION
Fix issue I mentioned in #43
