### PR TITLE
Fix vagrant-pe_build for PE 2.8.5

### DIFF
--- a/lib/pe_build/release/2_8.rb
+++ b/lib/pe_build/release/2_8.rb
@@ -36,4 +36,5 @@ module PEBuild::Release
   @releases['2.8.2'] = two_eight_x
   @releases['2.8.3'] = two_eight_x
   @releases['2.8.4'] = two_eight_x
+  @releases['2.8.5'] = two_eight_x
 end


### PR DESCRIPTION
Trivial patch to add 2.8.5 to two_eight_x releases.
