### PR TITLE
Call I18n reload after adding value to path

### DIFF
--- a/lib/pe_build.rb
+++ b/lib/pe_build.rb
@@ -25,3 +25,4 @@ end
 
 # I18n to load the en locale
 I18n.load_path << File.expand_path("locales/en.yml", PEBuild.template_dir)
+I18n.reload!


### PR DESCRIPTION
Otherwise, the translations still won't be available. See https://github.com/dotless-de/vagrant-vbguest/issues/107 for a discussion around a similar issue in an unrelated plugin. I noticed this issue when I had a bad configuration and started getting error messages like this.

```
[reidmv@pseudonix007:~/vagrant/seteam/] % vagrant provision centos64d --provision-with pe_bootstrap
[centos64d] Running provisioner: pe_bootstrap...
translation missing: en.pebuild.transfer.open_uri.download_failed
```
