### PR TITLE
Intelligently set ext for posix pre-release builds

### DIFF
--- a/lib/pe_build/cap/detect_installer/posix.rb
+++ b/lib/pe_build/cap/detect_installer/posix.rb
@@ -50,7 +50,16 @@ class PEBuild::Cap::DetectInstaller::POSIX < PEBuild::Cap::DetectInstaller::Base
   end
 
   def ext
-    'tar.gz'
+    # Posix release versions of Puppet Enterprise are packaged as .tar.gz
+    # files. Pre-release builds are not gzip'd. Select a default extension
+    # accordingly. As usual, for exceptional circumstances it's always possible
+    # to specify an explicit filename rather than relying on the
+    # detect_installer capability.
+    if @version =~ /^\d+\.\d+\.\d+$/
+      'tar.gz'
+    else
+      'tar'
+    end
   end
 
   private


### PR DESCRIPTION
The detect_installer capability of the pe_bootstrap provisioner will try to intelligently determine the PE installer filename for a given platform. On Posix, PE releases are packaged as .tar.gz files. However, if you have access to pre-release builds of PE, those builds will not be gzipped, they will simply be .tar files.

This commit updates the posix detect_installer capability to understand when a pre-release build is being asked for, and set the extension to "tar" in that scenario. For released builds, the "tar.gz" extension is appropriately selected.
