### PR TITLE
Find Windows installer using %SYSTEMDRIVE%\vagrant

### DIFF
--- a/lib/pe_build/cap/run_install/windows.rb
+++ b/lib/pe_build/cap/run_install/windows.rb
@@ -15,7 +15,8 @@ class PEBuild::Cap::RunInstall::Windows
       return
     end
 
-    root = File.join('\\\\VBOXSVR\\vagrant', PEBuild::WORK_DIR)
+    root = machine.communicate.shell.cmd('ECHO %SYSTEMDRIVE%')[:data][0][:stdout].chomp
+    root = File.join("#{root}\\vagrant", PEBuild::WORK_DIR)
 
     # The installer will be fed to msiexec. That means the File.join() method
     # is of limited use since it won't execute on the Windows system


### PR DESCRIPTION
- Remove dependency on VirtualBox share existing, and instead rely on Vagrants behavior with
  automatically creating a synced_folder at c:\vagrant
