### PR TITLE
fix TLS Error for windows agents

### DIFF
--- a/lib/pe_build/cap/stage_installer/windows.rb
+++ b/lib/pe_build/cap/stage_installer/windows.rb
@@ -27,7 +27,7 @@ class PEBuild::Cap::StageInstaller::Windows
       on_machine(machine, <<-EOS)
 $DestDir = (Get-Item -Path "#{dest_dir}").FullName
 Write-Host "Downloading #{filename} to: ${DestDir}"
-
+[System.Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
 (New-Object System.Net.WebClient).DownloadFile("#{uri}","$DestDir/#{filename}")
 EOS


### PR DESCRIPTION
Unless the specific TLS protocol is specified, some Windows agents will return an error about not being able to set up a TLS/SSL channel to the puppet server.